### PR TITLE
Fix boundary detection bug related to fixed positioning

### DIFF
--- a/src/popper/utils/getBoundaries.js
+++ b/src/popper/utils/getBoundaries.js
@@ -27,7 +27,7 @@ export default function getBoundaries(popper, padding, boundariesElement) {
         const { left, top } = getOffsetRectRelativeToViewport(offsetParent);
         const { clientWidth: width, clientHeight: height } = window.document.documentElement;
 
-        if (getPosition(popper) === 'fixed') {
+        if (isFixed(popper) || getPosition(popper) === 'fixed') {
             boundaries.right = width;
             boundaries.bottom = height;
         } else {


### PR DESCRIPTION
The getBoundaries function was not correctly identifying the popper as
being fixed position which resulted in incorrect boundary detection when
any scroll parent was scrolled.